### PR TITLE
Handle nil encoding

### DIFF
--- a/Sources/SwiftJSONType/SwiftJSONType.swift
+++ b/Sources/SwiftJSONType/SwiftJSONType.swift
@@ -19,7 +19,12 @@ public struct JSONType {
 // MARK: - Encodable
 extension JSONType: Encodable {
     public func encode(to encoder: Encoder) throws {
-        try value?.encode(to: encoder)
+        if let value = value {
+            try value.encode(to: encoder)
+        } else {
+            var singleValueContainerEncoder = encoder.singleValueContainer()
+            try singleValueContainerEncoder.encodeNil()
+        }
     }
 }
 

--- a/Tests/SwiftJSONTypeTests/SwiftJSONTypeTests.swift
+++ b/Tests/SwiftJSONTypeTests/SwiftJSONTypeTests.swift
@@ -69,7 +69,7 @@ final class SwiftJSONTypeTests: XCTestCase {
     }
 
     func testEncodableObject() {
-        let dict0: [String: JSONType] = ["baz": 100, "rect": Json(CGRect(x: 12, y: 12, width: 12, height: 12))]
+        let dict0: [String: JSONType] = ["baz": 100, "rect": Json(CGRect(x: 12, y: 12, width: 12, height: 12)), "obj": nil]
         do {
             let encodedData = try JSONEncoder().encode(dict0)
             XCTAssertFalse(encodedData.isEmpty)
@@ -77,6 +77,7 @@ final class SwiftJSONTypeTests: XCTestCase {
             XCTAssertNotNil(bar)
             XCTAssertEqual(bar.baz, 100)
             XCTAssertEqual(bar.rect, CGRect(x: 12, y: 12, width: 12, height: 12))
+            XCTAssertNil(bar.obj)
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -96,12 +97,8 @@ final class SwiftJSONTypeTests: XCTestCase {
 
 // MARK: - Test Codable Class
 
-class Bar: Codable {
+struct Bar: Codable {
     let baz: Int?
     let rect: CGRect
-
-    init(baz: Int?) {
-        self.baz = baz
-        self.rect = .zero
-    }
+    let obj: String?
 }


### PR DESCRIPTION
# Changes
Fixes nil being encoded as an empty dictionary. If the value was nil and encode was called on it then nothing would happen. The fix is to unwrap the value else encode nil.

# Test Plan 
Added unit test for encoding nil